### PR TITLE
Adding support for journeys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.3.0
+before_install: gem install bundler -v 1.12.5

--- a/lib/maropost_api.rb
+++ b/lib/maropost_api.rb
@@ -7,6 +7,7 @@ require "maropost_api/parser/entity_parser"
 require "maropost_api/client"
 require "maropost_api/contacts"
 require "maropost_api/workflows"
+require "maropost_api/journeys"
 require "maropost_api/global_unsubscribes"
 
 module MaropostApi

--- a/lib/maropost_api/client.rb
+++ b/lib/maropost_api/client.rb
@@ -8,6 +8,10 @@ module MaropostApi
       @contacts ||= Contacts.new(request: @request)
     end
 
+    def journeys
+      @journeys ||= Journeys.new(request: @request)
+    end
+
     def workflows
       @workflows ||= Workflows.new(request: @request)
     end

--- a/lib/maropost_api/journeys.rb
+++ b/lib/maropost_api/journeys.rb
@@ -1,0 +1,23 @@
+module MaropostApi
+  class Journeys
+    def initialize(request:, parser: Parser::EntityParser.new)
+      @request = request
+      @parser = parser
+    end
+
+    def stop(journey_id:, contact_id:)
+      response = @request.put(endpoint: "/journeys/#{journey_id}/stop/#{contact_id}.json")
+      Response.new(response: response, parser: @parser).call
+    end
+
+    def start(journey_id:, contact_id:)
+      response = @request.put(endpoint: "/journeys/#{journey_id}/start/#{contact_id}.json")
+      Response.new(response: response, parser: @parser).call
+    end
+
+    def reset(journey_id:, contact_id:)
+      response = @request.put(endpoint: "/journeys/#{journey_id}/reset/#{contact_id}.json")
+      Response.new(response: response, parser: @parser).call
+    end
+  end
+end

--- a/lib/maropost_api/journeys.rb
+++ b/lib/maropost_api/journeys.rb
@@ -19,5 +19,10 @@ module MaropostApi
       response = @request.put(endpoint: "/journeys/#{journey_id}/reset/#{contact_id}.json")
       Response.new(response: response, parser: @parser).call
     end
+
+    def stop_all_journeys(email:)
+      response = @request.put(endpoint: "/journeys/stop_all_journeys.json?email=#{CGI.escape(email)}")
+      Response.new(response: response, parser: @parser).call
+    end
   end
 end

--- a/lib/maropost_api/version.rb
+++ b/lib/maropost_api/version.rb
@@ -1,3 +1,3 @@
 module MaropostApi
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/maropost_api.svg)](https://badge.fury.io/rb/maropost_api)
+[![Build Status](https://travis-ci.org/hosseintoussi/maropost_api.svg?branch=adding-support-for-journeys)](https://travis-ci.org/hosseintoussi/maropost_api)
 
 # MaropostApi
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,26 @@ client.contacts.update(contact_id: '<id>', params: {email: 'test@example.com', f
 # To unsubscribe a contact from all lists
 client.contacts.unsubscribe_all_lists(email: 'test@example.com')
 
+# To check if a contact is in DNM list:
+client.global_unsubscribes.find_by_email(email: 'test@example.com')
+
+# To add a contact to DNM list:
+client.global_unsubscribes.add_to_dnm(email: 'test@example.com')
+
+# To start a journey for a contact
+client.journeys.start(journey_id: '<journey_id>', contact_id: '<contact_id>')
+
+# To stop journey for a contact
+client.journeys.stop(journey_id: journey_id>', contact_id: '<contact_id>')
+
+# To reset a journey for a contact
+client.journeys.reset(journey_id: '<journey_id>', contact_id: '<contact_id>')
+
+# To stop all journeys for a contact
+client.journeys.stop_all_journeys(email: 'test@example.com')
+
+## Endpoints that are going to be deprecated soon:
+
 # To start a workflow for a contact
 client.workflows.start(workflow_id: '<workflow_id>', contact_id: '<contact_id>')
 
@@ -56,12 +76,6 @@ client.workflows.stop(workflow_id: '<workflow_id>', contact_id: '<contact_id>')
 
 # To reset a workflow for a contact
 client.workflows.reset(workflow_id: '<workflow_id>', contact_id: '<contact_id>')
-
-# To check if a contact is in DNM list:
-client.global_unsubscribes.find_by_email(email: 'test@example.com')
-
-# To add a contact to DNM list:
-client.global_unsubscribes.add_to_dnm(email: 'test@example.com')
 ```
 
 ## Development

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ client.global_unsubscribes.add_to_dnm(email: 'test@example.com')
 client.journeys.start(journey_id: '<journey_id>', contact_id: '<contact_id>')
 
 # To stop journey for a contact
-client.journeys.stop(journey_id: journey_id>', contact_id: '<contact_id>')
+client.journeys.stop(journey_id: '<journey_id>', contact_id: '<contact_id>')
 
 # To reset a journey for a contact
 client.journeys.reset(journey_id: '<journey_id>', contact_id: '<contact_id>')

--- a/spec/cassettes/MaropostApi_Journeys/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/reset/742520380.json
+    body:
+      encoding: UTF-8
+      string: '{"auth_token":"TOKEN"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - a08e15dd-1189-40e7-8a88-3b70139784dc
+      Etag:
+      - W/"f48aa008871496dbac5bc9c59d089984"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.046516'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 01 Sep 2016 05:34:36 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.0.21
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 5.0.21
+    body:
+      encoding: UTF-8
+      string: '{"message":"Workflow Contact reset successfully!"}'
+    http_version:
+  recorded_at: Thu, 01 Sep 2016 05:34:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_start/with_correct_params/sends_start_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_start/with_correct_params/sends_start_request_with_provided_params.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/start/742520380.json
+    body:
+      encoding: UTF-8
+      string: '{"auth_token":"TOKEN"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 2fb7ee14-7d18-48de-9227-961e1fe8f094
+      Etag:
+      - W/"0049d9d3ca124f203efac2fcec51af57"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.037465'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 01 Sep 2016 05:34:34 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.0.21
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 5.0.21
+    body:
+      encoding: UTF-8
+      string: '{"message":"Success! Paused contact started."}'
+    http_version:
+  recorded_at: Thu, 01 Sep 2016 05:34:35 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/stop/742520380.json
+    body:
+      encoding: UTF-8
+      string: '{"auth_token":"TOKEN"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - d56b7e63-2c29-4171-8083-2c8f8676506d
+      Etag:
+      - W/"c73b54a93bda419e048ca4b823f773fc"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.030427'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 01 Sep 2016 05:34:35 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.0.21
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 5.0.21
+    body:
+      encoding: UTF-8
+      string: '{"message":"Success! Workflow stopped for this contact."}'
+    http_version:
+  recorded_at: Thu, 01 Sep 2016 05:34:35 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_stop_all_journeys/with_correct_params/stops_all_the_journeys_for_the_provided_email.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_stop_all_journeys/with_correct_params/stops_all_the_journeys_for_the_provided_email.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/stop_all_journeys.json?email=example@gmail.com
+    body:
+      encoding: UTF-8
+      string: '{"auth_token":"TOKEN"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - ebe97603-e97f-492c-8a6f-04eea2a06611
+      Etag:
+      - W/"656683cbbf20cb10a2c8d7bc359c0603"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.018292'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 01 Sep 2016 06:48:14 GMT
+      Set-Cookie:
+      - _maropost_session=25213cddf819c04811f34a9a70fc105a; path=/; expires=Thu, 01
+        Sep 2016 18:48:14 -0000; HttpOnly
+      X-Powered-By:
+      - Phusion Passenger 5.0.21
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 5.0.21
+    body:
+      encoding: UTF-8
+      string: '{"message":"Success! All workflows are stopped for this contact."}'
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 06:48:14 GMT
+recorded_with: VCR 2.9.3

--- a/spec/maropost_api/journeys_spec.rb
+++ b/spec/maropost_api/journeys_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe MaropostApi::Journeys do
+  before do
+    @client = MaropostApi::Client.new(auth_token: TOKEN, account_number: ACCOUNT_ID)
+  end
+
+  describe "#start", vcr: true do
+    context "with correct params" do
+      it "sends start request with provided params" do
+        journey_id = "12429"
+        contact_id = "742520380"
+
+        response = @client.journeys.start(journey_id: journey_id, contact_id: contact_id)
+        expect(response.message).to include('Success')
+      end
+    end
+  end
+
+  describe "#stop", vcr: true do
+    context "with correct params" do
+      it "sends stop request with provided params" do
+        journey_id = "12429"
+        contact_id = "742520380"
+
+        response = @client.journeys.stop(journey_id: journey_id, contact_id: contact_id)
+        expect(response.message).to include('Success')
+      end
+    end
+  end
+
+  describe "#reset", vcr: true do
+    context "with correct params" do
+      it "sends reset request with provided params" do
+        journey_id = "12429"
+        contact_id = "742520380"
+
+        response = @client.journeys.reset(journey_id: journey_id, contact_id: contact_id)
+        expect(response.message).to include('successfully')
+      end
+    end
+  end
+end

--- a/spec/maropost_api/journeys_spec.rb
+++ b/spec/maropost_api/journeys_spec.rb
@@ -12,7 +12,7 @@ describe MaropostApi::Journeys do
         contact_id = "742520380"
 
         response = @client.journeys.start(journey_id: journey_id, contact_id: contact_id)
-        expect(response.message).to include('Success')
+        expect(response.message).to include("Success")
       end
     end
   end
@@ -24,7 +24,7 @@ describe MaropostApi::Journeys do
         contact_id = "742520380"
 
         response = @client.journeys.stop(journey_id: journey_id, contact_id: contact_id)
-        expect(response.message).to include('Success')
+        expect(response.message).to include("Success")
       end
     end
   end
@@ -36,7 +36,16 @@ describe MaropostApi::Journeys do
         contact_id = "742520380"
 
         response = @client.journeys.reset(journey_id: journey_id, contact_id: contact_id)
-        expect(response.message).to include('successfully')
+        expect(response.message).to include("successfully")
+      end
+    end
+  end
+
+  describe "#stop_all_journeys", vcr: true do
+    context "with correct params" do
+      it "stops all the journeys for the provided email" do
+        response = @client.journeys.stop_all_journeys(email: "example@gmail.com")
+        expect(response.message).to include("Success")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "maropost_api"
-require "VCR"
+require "vcr"
 
 TOKEN = "TOKEN".freeze
 ACCOUNT_ID = "ACCOUNT_ID".freeze


### PR DESCRIPTION
This PR is to support the new change of Maropost that is renaming "Workflows" to "Journeys". However, as `/workflows` is still live, we keep it there for compatibility.

There is  also a new feature, that is to stop all journeys for a contact, and this PR is implementing that. 

There are some minor changes for travisCI as well as adding travis yml file.

@vomitaftertaste 