### PR TITLE
move the auth_token parameter to the query instead of the body

### DIFF
--- a/lib/maropost_api/request.rb
+++ b/lib/maropost_api/request.rb
@@ -3,6 +3,7 @@ require 'httparty'
 module MaropostApi
   class Request
     include HTTParty
+    debug_output $stdout unless ENV["RACK_ENV"] == "production"
 
     def initialize(auth_token:, account_number:)
       @auth_token = auth_token
@@ -26,7 +27,7 @@ module MaropostApi
 
     def set_default_config
       @base_uri = "http://api.maropost.com/accounts/#{@account_number}"
-      @default_params = { auth_token: @auth_token }
+      @default_params = { }
     end
 
     def uri(endpoint)
@@ -34,8 +35,11 @@ module MaropostApi
     end
 
     def payload(params)
-      { body: merge_auth_token(params).to_json,
-        headers: { 'Content-Type' => 'application/json' } }
+      {
+        query: { auth_token: @auth_token },
+        body: merge_auth_token(params).to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      }
     end
 
     def merge_auth_token(params)

--- a/lib/maropost_api/request.rb
+++ b/lib/maropost_api/request.rb
@@ -3,7 +3,6 @@ require 'httparty'
 module MaropostApi
   class Request
     include HTTParty
-    debug_output $stdout unless ENV["RACK_ENV"] == "production"
 
     def initialize(auth_token:, account_number:)
       @auth_token = auth_token

--- a/lib/maropost_api/version.rb
+++ b/lib/maropost_api/version.rb
@@ -1,3 +1,3 @@
 module MaropostApi
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/maropost_api.gemspec
+++ b/maropost_api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "~> 1.2"
   spec.add_development_dependency "pry"
 
   spec.add_runtime_dependency "httparty"

--- a/spec/cassettes/MaropostApi_Contacts/_add_to_list/when_correct_params_are_passed/sends_upsert_request_with_provided_contact_params.yml
+++ b/spec/cassettes/MaropostApi_Contacts/_add_to_list/when_correct_params_are_passed/sends_upsert_request_with_provided_contact_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json?list_ids=43405
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json?auth_token=TOKEN&list_ids=43405
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","email":"example@gmail.com","first_name":"dev"}'
+      string: '{"email":"example@gmail.com","first_name":"dev"}'
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -29,24 +27,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 0d91ef93-649a-4018-9463-246b511d4cd9
+      - 8d6dab54-8d5c-4999-abf2-b51714582ec1
       Etag:
-      - W/"771098e2761b6433944f7dadc84ca133"
+      - W/"9ece69754cdc9899325006694f47d982"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.039545'
+      - '0.071367'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:55 GMT
+      - Thu, 23 Feb 2017 04:45:17 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.332-04:00","updated_at":"2016-07-19T10:08:55.332-04:00"}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:55 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:17.039-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Contacts/_create/when_correct_params_are_passed/sends_a_post_requests_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Contacts/_create/when_correct_params_are_passed/sends_a_post_requests_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","email":"example@gmail.com","first_name":"dev"}'
+      string: '{"email":"example@gmail.com","first_name":"dev"}'
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -29,24 +27,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - dd99aaaa-2327-4822-9f7e-4c984c85a7ba
+      - 696237be-b1c4-4a44-84a5-8e1da2bc5e86
       Etag:
-      - W/"26762581bf9ac3316724663f97079b16"
+      - W/"9fe8251aaf68437f080006521d33a510"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.027904'
+      - '0.026760'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:57 GMT
+      - Thu, 23 Feb 2017 04:45:18 GMT
       X-Powered-By:
       - Phusion Passenger 5.0.21
       Server:
       - nginx/1.8.0 + Phusion Passenger 5.0.21
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00"}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:57 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:17.000-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Contacts/_find_by_email/when_searching_for_a_contact_by_email/returns_the_contact_if_it_exists.yml
+++ b/spec/cassettes/MaropostApi_Contacts/_find_by_email/when_searching_for_a_contact_by_email/returns_the_contact_if_it_exists.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts/email.json?contact%5Bemail%5D=example@gmail.com
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts/email.json?auth_token=TOKEN&contact%5Bemail%5D=example@gmail.com
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,25 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - b6113280-e4a4-4887-9f84-52b72e8176e9
+      - 8ca89e60-e512-475c-8f46-41f05b6e7cdb
       Etag:
-      - W/"0d2e3e7810bc00ddc6c6ea7b10990f3b"
+      - W/"0524223afb12de35ab554756004b9d80"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.023686'
+      - '0.058145'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:55 GMT
+      - Thu, 23 Feb 2017 04:45:17 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00","orders":[],"list_subscriptions":[{"list_id":43405,"name":"test-haidar","status":"Subscribed","created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00"}],"workflows":[{"id":9359,"name":"haidar-test-wf","workflow_contact_status":"Active","workflow_status":"Enabled","created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00"}],"tags":[]}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:55 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:17.000-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null,"orders":[],"list_subscriptions":[{"list_id":43405,"name":"test-haidar","status":"Subscribed","created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:24:37.000-05:00"},{"list_id":69208,"name":"[OPS]
+        DO NOT MAILING LIST - for testing ","status":"Subscribed","created_at":"2017-01-22T00:56:25.000-05:00","updated_at":"2017-01-22T00:56:25.000-05:00"}],"workflows":[{"id":9359,"name":"spec-test-workflow-do-not-delete","workflow_contact_status":"Unsubscribed","workflow_status":"Enabled","created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-20T10:42:43.000-04:00"}],"tags":[]}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Contacts/_update/when_correct_are_passed_to_update_a_contact_/sends_a_put_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Contacts/_update/when_correct_are_passed_to_update_a_contact_/sends_a_put_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","email":"example@gmail.com","first_name":"dev"}'
+      string: '{"email":"example@gmail.com","first_name":"dev"}'
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -29,32 +27,32 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 83484afd-1341-4eb0-b83a-f5c33deea59f
+      - 7f4fc63b-ec00-4627-a780-25122a1664ac
       Etag:
-      - W/"26762581bf9ac3316724663f97079b16"
+      - W/"7cd68fe7656621cf19398f88a8fbea53"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.026789'
+      - '0.046176'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:58 GMT
+      - Thu, 23 Feb 2017 04:45:19 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00"}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:58 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:19.592-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:19 GMT
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts/742521850.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts/742521850.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","first_name":"test"}'
+      string: '{"first_name":"test"}'
     headers:
       Content-Type:
       - application/json
@@ -67,8 +65,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -78,24 +74,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 7d10be5b-150d-4a77-8865-cf9fa209c64d
+      - 5eff7dd5-b3cd-48d1-b09e-7d220e594eba
       Etag:
-      - W/"39c9f61858fd12219015cab43cda71fa"
+      - W/"060601eeef4ba14900fcd83d15101081"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.030517'
+      - '0.069596'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:58 GMT
+      - Thu, 23 Feb 2017 04:45:20 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"test","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:58.803-04:00"}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:58 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"test","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:20.217-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Contacts/_upsert/when_correct_params_are_passed/sends_a_post_requests_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Contacts/_upsert/when_correct_params_are_passed/sends_a_post_requests_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/contacts.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","email":"example@gmail.com","first_name":"dev_change"}'
+      string: '{"email":"example@gmail.com","first_name":"dev_change"}'
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -29,24 +27,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - dd99aaaa-2327-4822-9f7e-4c984c85a7ba
+      - dfcbb615-2544-4a82-98ea-e6f7db7821bf
       Etag:
-      - W/"26762581bf9ac3316724663f97079b16"
+      - W/"a4a1454dd53c5a81632ba87b1b9b2cc3"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.027904'
+      - '0.030283'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 19 Jul 2016 14:08:57 GMT
+      - Thu, 23 Feb 2017 04:45:18 GMT
       X-Powered-By:
       - Phusion Passenger 5.0.21
       Server:
       - nginx/1.8.0 + Phusion Passenger 5.0.21
     body:
       encoding: UTF-8
-      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev_change","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2016-07-19T10:08:55.000-04:00"}'
-    http_version:
-  recorded_at: Tue, 19 Jul 2016 14:08:57 GMT
+      string: '{"id":742521850,"email":"example@gmail.com","first_name":"dev_change","last_name":null,"phone":null,"fax":null,"created_at":"2016-07-19T10:08:55.000-04:00","updated_at":"2017-02-22T23:45:18.969-05:00","channel":null,"chakra0_411":null,"chakra1_157":null,"chakra2_158":null,"chakra3_159":null,"chakra4_160":null,"chakra5_161":null,"chakra6_162":null,"chakra7_163":null,"codex_download_code":null}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_GlobalUnsubscribes/_add_to_dnm/when_adding_a_contact_in_dnm_list/returns_the_contact_s_email.yml
+++ b/spec/cassettes/MaropostApi_GlobalUnsubscribes/_add_to_dnm/when_adding_a_contact_in_dnm_list/returns_the_contact_s_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN","global_unsubscribe":{"email":"example5@gmail.com"}}'
+      string: '{"global_unsubscribe":{"email":"example5@gmail.com"}}'
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Status:
       - 201 Created
       Cache-Control:
@@ -29,26 +27,26 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - f51b30e4-fc47-4bba-badc-80a53c8e5744
+      - e7c3f971-6939-4b6e-a7af-e4719dc38e0d
       Location:
       - "/accounts/ACCOUNT_ID/global_unsubscribes"
       Etag:
-      - W/"fedcde551918da6669345843075f1af3"
+      - W/"f25b203ded9f6d2a0515dfACCOUNT_ID334a938"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.021909'
+      - '0.024268'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 15 Aug 2016 04:16:23 GMT
+      - Thu, 23 Feb 2017 04:47:41 GMT
       X-Powered-By:
       - Phusion Passenger 5.0.21
       Server:
       - nginx/1.8.0 + Phusion Passenger 5.0.21
     body:
       encoding: UTF-8
-      string: '{"id":85080340,"email":"example5@gmail.com","created_at":"2016-08-15T00:16:23.476-04:00","updated_at":"2016-08-15T00:16:23.476-04:00"}'
-    http_version:
-  recorded_at: Mon, 15 Aug 2016 04:16:23 GMT
+      string: '{"id":104109152,"account_id":ACCOUNT_ID,"email":"example5@gmail.com","created_at":"2017-02-22T23:47:41.707-05:00","updated_at":"2017-02-22T23:47:41.707-05:00"}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:47:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_GlobalUnsubscribes/_find_by_email/when_contact_exists_in_DNM_list/returns_contact_s_email.yml
+++ b/spec/cassettes/MaropostApi_GlobalUnsubscribes/_find_by_email/when_contact_exists_in_DNM_list/returns_contact_s_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes/email.json?contact%5Bemail%5D=example@gmail.com
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes/email.json?auth_token=TOKEN&contact%5Bemail%5D=example2@gmail.com
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - bb2a1ee5-ed90-4120-ba6f-d4a78eab47fc
+      - 85334344-130a-4946-9c5f-c898e073d540
       Etag:
-      - W/"9aaca4c8ff89f73c521f33efd2cc38f7"
+      - W/"f29ac3d8e48790cf790b25a1201803c7"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.013351'
+      - '0.030247'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 15 Aug 2016 04:16:22 GMT
+      - Thu, 23 Feb 2017 04:47:40 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
-      string: '{"id":83045963,"email":"example@gmail.com","created_at":"2016-07-19T10:15:09.000-04:00","updated_at":"2016-07-19T10:15:09.000-04:00"}'
-    http_version:
-  recorded_at: Mon, 15 Aug 2016 04:16:22 GMT
+      string: '{"id":85080104,"account_id":ACCOUNT_ID,"email":"example2@gmail.com","created_at":"2016-08-15T00:02:33.000-04:00","updated_at":"2016-08-15T00:02:33.000-04:00"}'
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:47:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_GlobalUnsubscribes/_find_by_email/when_contact_exists_in_DNM_list/when_contact_does_not_exist_in_DNM_list/returns_a_message.yml
+++ b/spec/cassettes/MaropostApi_GlobalUnsubscribes/_find_by_email/when_contact_exists_in_DNM_list/when_contact_does_not_exist_in_DNM_list/returns_a_message.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes/email.json?contact%5Bemail%5D=example3@gmail.com
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/global_unsubscribes/email.json?auth_token=TOKEN&contact%5Bemail%5D=example3@gmail.com
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 12d01a06-7b16-40ca-868e-470cd7d368d1
+      - 3115d29f-259b-4711-8013-14654dabee93
       Etag:
       - W/"897c9d0ddfe3d51e183ff1607cb19a4c"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.014238'
+      - '0.015481'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 15 Aug 2016 04:16:22 GMT
+      - Thu, 23 Feb 2017 04:47:41 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Contact not present.","status":404}'
-    http_version:
-  recorded_at: Mon, 15 Aug 2016 04:16:23 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:47:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/reset/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/reset/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,17 +29,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - a08e15dd-1189-40e7-8a88-3b70139784dc
+      - 8dc0d512-fb9e-4231-8249-a7e3af1b9acb
       Etag:
       - W/"f48aa008871496dbac5bc9c59d089984"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.046516'
+      - '0.036186'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 01 Sep 2016 05:34:36 GMT
+      - Thu, 23 Feb 2017 04:49:44 GMT
       X-Powered-By:
       - Phusion Passenger 5.0.21
       Server:
@@ -49,6 +47,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Workflow Contact reset successfully!"}'
-    http_version:
-  recorded_at: Thu, 01 Sep 2016 05:34:36 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:49:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_start/with_correct_params/sends_start_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_start/with_correct_params/sends_start_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/start/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/start/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,17 +29,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 2fb7ee14-7d18-48de-9227-961e1fe8f094
+      - 3f0df3e9-db8b-4d45-a91e-8301a331326b
       Etag:
       - W/"0049d9d3ca124f203efac2fcec51af57"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.037465'
+      - '0.027710'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 01 Sep 2016 05:34:34 GMT
+      - Thu, 23 Feb 2017 04:49:43 GMT
       X-Powered-By:
       - Phusion Passenger 5.0.21
       Server:
@@ -49,6 +47,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Success! Paused contact started."}'
-    http_version:
-  recorded_at: Thu, 01 Sep 2016 05:34:35 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:49:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/stop/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/12429/stop/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - d56b7e63-2c29-4171-8083-2c8f8676506d
+      - b6b8084e-833b-4b6f-924f-5f699d9c551b
       Etag:
       - W/"c73b54a93bda419e048ca4b823f773fc"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.030427'
+      - '0.036603'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 01 Sep 2016 05:34:35 GMT
+      - Thu, 23 Feb 2017 04:49:44 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Success! Workflow stopped for this contact."}'
-    http_version:
-  recorded_at: Thu, 01 Sep 2016 05:34:35 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:49:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Journeys/_stop_all_journeys/with_correct_params/stops_all_the_journeys_for_the_provided_email.yml
+++ b/spec/cassettes/MaropostApi_Journeys/_stop_all_journeys/with_correct_params/stops_all_the_journeys_for_the_provided_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/stop_all_journeys.json?email=example@gmail.com
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/journeys/stop_all_journeys.json?auth_token=TOKEN&email=example@gmail.com
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,27 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - ebe97603-e97f-492c-8a6f-04eea2a06611
+      - bc980bb4-7619-440c-947d-c9f185f44938
       Etag:
       - W/"656683cbbf20cb10a2c8d7bc359c0603"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.018292'
+      - '0.026071'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 01 Sep 2016 06:48:14 GMT
-      Set-Cookie:
-      - _maropost_session=25213cddf819c04811f34a9a70fc105a; path=/; expires=Thu, 01
-        Sep 2016 18:48:14 -0000; HttpOnly
+      - Thu, 23 Feb 2017 04:49:45 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Success! All workflows are stopped for this contact."}'
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 06:48:14 GMT
+  recorded_at: Thu, 23 Feb 2017 04:49:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Workflows/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Workflows/_reset/with_correct_params/sends_reset_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/reset/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/reset/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 3c9934e3-a6c1-47d4-8956-bc753ed609a6
+      - a0f61ce9-aa28-4547-a67f-8d2ce1d39e06
       Etag:
       - W/"f48aa008871496dbac5bc9c59d089984"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.045826'
+      - '0.056475'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 02 Aug 2016 05:59:09 GMT
+      - Thu, 23 Feb 2017 04:45:26 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Workflow Contact reset successfully!"}'
-    http_version:
-  recorded_at: Tue, 02 Aug 2016 05:59:09 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Workflows/_start/with_correct_params/sends_start_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Workflows/_start/with_correct_params/sends_start_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/start/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/start/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 7e6163cc-9901-42a6-8790-794ba251123a
+      - a973ab91-3c5f-42ca-9926-39c545599804
       Etag:
       - W/"0049d9d3ca124f203efac2fcec51af57"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.027191'
+      - '0.028940'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 02 Aug 2016 05:59:08 GMT
+      - Thu, 23 Feb 2017 04:45:25 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Success! Paused contact started."}'
-    http_version:
-  recorded_at: Tue, 02 Aug 2016 05:59:08 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/MaropostApi_Workflows/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
+++ b/spec/cassettes/MaropostApi_Workflows/_stop/with_correct_params/sends_stop_request_with_provided_params.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/stop/742520380.json
+    uri: http://api.maropost.com/accounts/ACCOUNT_ID/workflows/9359/stop/742520380.json?auth_token=TOKEN
     body:
       encoding: UTF-8
-      string: '{"auth_token":"TOKEN"}'
+      string: "{}"
     headers:
       Content-Type:
       - application/json
@@ -18,8 +18,6 @@ http_interactions:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Connection:
-      - keep-alive
       Vary:
       - Accept-Encoding
       Status:
@@ -31,24 +29,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - c4056fc2-6c03-4c05-b50a-0bfb1a9312ea
+      - a0bcb84d-fd7c-48b8-9129-645c78b35c69
       Etag:
       - W/"c73b54a93bda419e048ca4b823f773fc"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.029048'
+      - '0.032820'
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Tue, 02 Aug 2016 05:59:08 GMT
+      - Thu, 23 Feb 2017 04:45:25 GMT
       X-Powered-By:
-      - Phusion Passenger 5.0.21
+      - Phusion Passenger 5.0.14
       Server:
-      - nginx/1.8.0 + Phusion Passenger 5.0.21
+      - nginx/1.8.0 + Phusion Passenger 5.0.14
     body:
       encoding: UTF-8
       string: '{"message":"Success! Workflow stopped for this contact."}'
-    http_version:
-  recorded_at: Tue, 02 Aug 2016 05:59:09 GMT
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 04:45:25 GMT
 recorded_with: VCR 2.9.3

--- a/spec/maropost_api/global_unsubscribes_spec.rb
+++ b/spec/maropost_api/global_unsubscribes_spec.rb
@@ -8,9 +8,9 @@ describe MaropostApi::GlobalUnsubscribes do
   describe "#find_by_email", vcr: true do
     context "when contact exists in DNM list" do
       it "returns contact's email" do
-        response = @client.global_unsubscribes.find_by_email(email: "example@gmail.com")
+        response = @client.global_unsubscribes.find_by_email(email: "example2@gmail.com")
 
-        expect(response.email).to eq("example@gmail.com")
+        expect(response.email).to eq("example2@gmail.com")
       end
 
     context "when contact does not exist in DNM list" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "maropost_api"
 require "vcr"
 
 TOKEN = "TOKEN".freeze
-ACCOUNT_ID = "ACCOUNT_ID".freeze
+ACCOUNT_ID = "0".freeze
 
 VCR.configure do |c|
   c.hook_into :webmock


### PR DESCRIPTION
after speaking with maropost tech support and them showing me how they
generate api requests, it seems that the supported way of using the api
is via having the auth_token as a url query parameter, instead of part
of the json payload.

testing it on our personal account seems to work properly. originally i
was having problems updating custom fields of contacts that are in the
dnm list, but after this change i was able to.

fixes #19 